### PR TITLE
fix order of nibbles in device_id_hex

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,8 +65,8 @@ pub fn device_id_hex() -> &'static str {
                 for (i, b) in device_id().iter().enumerate() {
                     let lo = b & 0xf;
                     let hi = (b >> 4) & 0xfu8;
-                    DEVICE_ID_STR[i*2] = hex[lo as usize];
-                    DEVICE_ID_STR[i*2+1] = hex[hi as usize];
+                    DEVICE_ID_STR[i*2] = hex[hi as usize];
+                    DEVICE_ID_STR[i*2+1] = hex[lo as usize];
                 }
             });
         }


### PR DESCRIPTION
Fixed the ordering of nibbles so that output is consistent with hex representation of device_id bytes.

For example, decimal 57 was printing as 93, but hex representation of 57 is 0x39.